### PR TITLE
[DNAB-2641] Atualização da versão do Tomcat para 9.0.108

### DIFF
--- a/TomcatGrailsPlugin.groovy
+++ b/TomcatGrailsPlugin.groovy
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 class TomcatGrailsPlugin {
-    def version = '9.0.97'
+    def version = '9.0.108'
     def grailsVersion = '2.5 > *'
     def scopes = [excludes: 'war']
     def title = 'Apache Tomcat plugin'

--- a/grails-app/conf/BuildConfig.groovy
+++ b/grails-app/conf/BuildConfig.groovy
@@ -18,7 +18,7 @@ grails.project.dependency.resolution = {
     }
 
     dependencies {
-        String tomcatVersion = '9.0.97'
+        String tomcatVersion = '9.0.108'
         String tomcatLogVersion = '8.5.2'
 
         compile "org.apache.tomcat.embed:tomcat-embed-core:$tomcatVersion"


### PR DESCRIPTION
### Impacto
Essa PR atualiza a versão do Tomcat para 9.0.108

### Link da tarefa no JIRA
https://asaasdev.atlassian.net/browse/DNAB-2641

### Prints do desenvolvimento
<img width="797" height="183" alt="image" src="https://github.com/user-attachments/assets/f5cf5f12-1952-4888-9752-c1d1559065a1" />

### Cenários testados
- Compilação com plugin local
- Compilação com plugin já no bucket S3
- Execução dos testes e2e